### PR TITLE
Prefer the reported namespace over the target namespace

### DIFF
--- a/config/prometheus/monitor.yaml
+++ b/config/prometheus/monitor.yaml
@@ -13,6 +13,7 @@ spec:
       port: https
       scheme: https
       bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+      honorLabels: true
       tlsConfig:
         insecureSkipVerify: true
   selector:


### PR DESCRIPTION
If we don't add this `namespace` will always be the namespace the exporter is running in and the reported namespace will be moved to the `exported_namespace` label

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog


<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
